### PR TITLE
Extendable precisions

### DIFF
--- a/lib/calendar_interval.ex
+++ b/lib/calendar_interval.ex
@@ -186,8 +186,8 @@ defmodule CalendarInterval do
       :month
 
   """
-  defmacro sigil_I({:<<>>, _, [string]}, []) do
-    Macro.escape(parse!(string))
+  def sigil_I(string, []) do
+    parse!(string)
   end
 
   @doc """

--- a/lib/calendar_interval.ex
+++ b/lib/calendar_interval.ex
@@ -2,6 +2,7 @@ defmodule CalendarInterval do
   @moduledoc """
   Functions for working with calendar intervals.
   """
+  alias CalendarInterval.Precision
 
   defstruct [:first, :last, :precision]
 
@@ -11,25 +12,11 @@ defmodule CalendarInterval do
           precision: precision()
         }
 
-  @type precision() :: :year | :month | :day | :hour | :minute | :second | {:microsecond, 1..6}
+  @type precision() :: CalendarInterval.Precision.precision()
 
-  @precisions [:year, :month, :day, :hour, :minute, :second] ++
-                for(i <- 1..6, do: {:microsecond, i})
-
-  @patterns [
-    {:year, 4, "-01-01 00:00:00.000000"},
-    {:month, 7, "-01 00:00:00.000000"},
-    {:day, 10, " 00:00:00.000000"},
-    {:hour, 13, ":00:00.000000"},
-    {:minute, 16, ":00.000000"},
-    {:second, 19, ".000000"},
-    {{:microsecond, 1}, 21, "00000"},
-    {{:microsecond, 2}, 22, "0000"},
-    {{:microsecond, 3}, 23, "000"},
-    {{:microsecond, 4}, 24, "00"},
-    {{:microsecond, 5}, 25, "0"}
-  ]
-
+  # Lowest possible precision
+  # Elixir does not support a better precision in it's datetime structs to this
+  # can be kept hardcoded.
   @microsecond {:microsecond, 6}
 
   @typedoc """
@@ -135,27 +122,39 @@ defmodule CalendarInterval do
 
   """
   @spec new(NaiveDateTime.t() | Date.t(), precision()) :: t()
-  def new(%NaiveDateTime{} = naive_datetime, precision) when precision in @precisions do
-    first = truncate(naive_datetime, precision)
-    last = first |> next_ndt(precision, 1) |> prev_ndt(@microsecond, 1)
+  def new(%NaiveDateTime{} = naive_datetime, precision) do
+    validate_precision(precision)
+    first = Precision.truncate(naive_datetime, precision)
+    last = first |> Precision.next_ndt(precision, 1) |> Precision.prev_ndt(@microsecond, 1)
     new(first, last, precision)
   end
 
-  def new(%Date{} = date, precision) when precision in @precisions do
+  def new(%Date{} = date, precision) do
+    validate_precision(precision)
     {:ok, ndt} = NaiveDateTime.new(date, ~T"00:00:00")
     new(ndt, precision)
   end
 
-  defp new(%NaiveDateTime{} = first, %NaiveDateTime{} = last, precision)
-       when precision in @precisions do
+  defp new(%NaiveDateTime{} = first, %NaiveDateTime{} = last, precision) do
+    validate_precision(precision)
+
     if NaiveDateTime.compare(first, last) in [:eq, :lt] do
       %CalendarInterval{first: first, last: last, precision: precision}
     else
-      first = format(first, precision)
-      last = format(last, precision)
+      first = Precision.format(first, precision)
+      last = Precision.format(last, precision)
 
       raise ArgumentError, """
-      cannot create interval from #{first} and #{last}, descending intervals are not supported\
+      Cannot create interval from #{first} and #{last}, descending intervals are not supported.\
+      """
+    end
+  end
+
+  defp validate_precision(precision) do
+    unless Precision.valid?(precision) do
+      raise ArgumentError, """
+      Cannot create interval with invalid precision #{inspect(precision)}. \
+      Available are #{inspect(Precision.precisions())}.\
       """
     end
   end
@@ -170,10 +169,11 @@ defmodule CalendarInterval do
 
   """
   @spec utc_now(precision()) :: t()
-  def utc_now(precision \\ @microsecond) when precision in @precisions do
+  def utc_now(precision \\ @microsecond) do
+    validate_precision(precision)
     now = NaiveDateTime.utc_now()
-    first = truncate(now, precision)
-    last = next_ndt(first, precision, 1) |> prev_ndt(@microsecond, 1)
+    first = Precision.truncate(now, precision)
+    last = Precision.next_ndt(first, precision, 1) |> Precision.prev_ndt(@microsecond, 1)
     new(first, last, precision)
   end
 
@@ -206,8 +206,8 @@ defmodule CalendarInterval do
   def parse!(string) do
     case String.split(string, "/", trim: true) do
       [string] ->
-        {ndt, precision} = do_parse!(string)
-        new(ndt, precision)
+        {:ok, precision, string} = Precision.parse(string)
+        new(NaiveDateTime.from_iso8601!(string), precision)
 
       [left, right] ->
         right = String.slice(left, 0, byte_size(left) - byte_size(right)) <> right
@@ -217,75 +217,9 @@ defmodule CalendarInterval do
     end
   end
 
-  for {precision, bytes, rest} <- @patterns do
-    defp do_parse!(<<_::unquote(bytes)-bytes>> = string) do
-      do_parse!(string <> unquote(rest))
-      |> put_elem(1, unquote(precision))
-    end
-  end
-
-  defp do_parse!(<<_::26-bytes>> = string) do
-    {NaiveDateTime.from_iso8601!(string), @microsecond}
-  end
-
-  defp next_ndt(ndt, :year, step), do: update_in(ndt.year, &(&1 + step))
-
-  defp next_ndt(%NaiveDateTime{year: year, month: month} = ndt, :month, step) do
-    {plus_year, month} = {div(month + step, 12), rem(month + step, 12)}
-
-    if month == 0 do
-      %{ndt | year: year + plus_year, month: 1}
-    else
-      %{ndt | year: year + plus_year, month: month}
-    end
-  end
-
-  defp next_ndt(ndt, precision, step) do
-    {count, unit} = precision_to_count_unit(precision)
-    NaiveDateTime.add(ndt, count * step, unit)
-  end
-
-  defp prev_ndt(ndt, :year, step), do: update_in(ndt.year, &(&1 - step))
-
-  # TODO: handle step != 1
-  defp prev_ndt(%NaiveDateTime{year: year, month: 1} = ndt, :month, step) do
-    %{ndt | year: year - 1, month: 12 - step + 1}
-  end
-
-  # TODO: handle step != 1
-  defp prev_ndt(%NaiveDateTime{month: month} = ndt, :month, step) do
-    %{ndt | month: month - step}
-  end
-
-  defp prev_ndt(ndt, precision, step) do
-    {count, unit} = precision_to_count_unit(precision)
-    NaiveDateTime.add(ndt, -count * step, unit)
-  end
-
-  defp precision_to_count_unit(:day), do: {24 * 60 * 60, :second}
-  defp precision_to_count_unit(:hour), do: {60 * 60, :second}
-  defp precision_to_count_unit(:minute), do: {60, :second}
-  defp precision_to_count_unit(:second), do: {1, :second}
-
-  defp precision_to_count_unit({:microsecond, exponent}) do
-    {1, Enum.reduce(1..exponent, 1, fn _, acc -> acc * 10 end)}
-  end
-
   @doc false
-  def count(%CalendarInterval{first: %{year: year1}, last: %{year: year2}, precision: :year}),
-    do: year2 - year1 + 1
-
-  def count(%CalendarInterval{
-        first: %{year: year1, month: month1},
-        last: %{year: year2, month: month2},
-        precision: :month
-      }),
-      do: month2 + year2 * 12 - month1 - year1 * 12 + 1
-
-  def count(%CalendarInterval{first: first, last: last, precision: precision}) do
-    {count, unit} = precision_to_count_unit(precision)
-    div(NaiveDateTime.diff(last, first, unit), count) + 1
-  end
+  def count(%CalendarInterval{first: first, last: last, precision: precision}),
+    do: Precision.count(first, last, precision)
 
   @doc """
   Returns string representation.
@@ -298,41 +232,13 @@ defmodule CalendarInterval do
   """
   @spec to_string(t()) :: String.t()
   def to_string(%CalendarInterval{first: first, last: last, precision: precision}) do
-    left = format(first, precision)
-    right = format(last, precision)
+    left = Precision.format(first, precision)
+    right = Precision.format(last, precision)
 
     if left == right do
       left
     else
-      format_left_right(left, right)
-    end
-  end
-
-  defp format_left_right(left, left) do
-    left
-  end
-
-  for i <- Enum.reverse([5, 8, 11, 14, 17, 20, 22, 23, 24, 25, 26]) do
-    defp format_left_right(
-           <<left::unquote(i)-bytes>> <> left_rest,
-           <<left::unquote(i)-bytes>> <> right_rest
-         ) do
-      left <> left_rest <> "/" <> right_rest
-    end
-  end
-
-  defp format_left_right(left, right) do
-    left <> "/" <> right
-  end
-
-  defp format(ndt, @microsecond) do
-    NaiveDateTime.to_string(ndt)
-  end
-
-  for {precision, bytes, _} <- @patterns do
-    defp format(ndt, unquote(precision)) do
-      NaiveDateTime.to_string(ndt)
-      |> String.slice(0, unquote(bytes))
+      Precision.format_left_right(left, right)
     end
   end
 
@@ -398,13 +304,13 @@ defmodule CalendarInterval do
 
     first =
       last
-      |> next_ndt(@microsecond, 1)
-      |> next_ndt(precision, count * (step - 1))
+      |> Precision.next_ndt(@microsecond, 1)
+      |> Precision.next_ndt(precision, count * (step - 1))
 
     last =
       first
-      |> next_ndt(precision, count)
-      |> prev_ndt(@microsecond, 1)
+      |> Precision.next_ndt(precision, count)
+      |> Precision.prev_ndt(@microsecond, 1)
 
     new(first, last, precision)
   end
@@ -438,12 +344,12 @@ defmodule CalendarInterval do
 
     first =
       first
-      |> prev_ndt(precision, count * step)
+      |> Precision.prev_ndt(precision, count * step)
 
     last =
       first
-      |> next_ndt(precision, count)
-      |> prev_ndt(@microsecond, 1)
+      |> Precision.next_ndt(precision, count)
+      |> Precision.prev_ndt(@microsecond, 1)
 
     new(first, last, precision)
   end
@@ -464,13 +370,19 @@ defmodule CalendarInterval do
 
   """
   @spec nest(t(), precision()) :: t()
-  def nest(%CalendarInterval{precision: old_precision} = interval, new_precision)
-      when new_precision in @precisions do
-    if precision_index(new_precision) > precision_index(old_precision) do
-      %{interval | precision: new_precision}
-    else
-      raise ArgumentError,
-            "cannot nest from #{inspect(old_precision)} to #{inspect(new_precision)}"
+  def nest(%CalendarInterval{precision: old_precision} = interval, new_precision) do
+    validate_precision(new_precision)
+
+    case Precision.compare(old_precision, new_precision) do
+      :eq ->
+        interval
+
+      :lt ->
+        %{interval | precision: new_precision}
+
+      _ ->
+        raise ArgumentError,
+              "cannot nest from #{inspect(old_precision)} to #{inspect(new_precision)}"
     end
   end
 
@@ -487,31 +399,20 @@ defmodule CalendarInterval do
 
   """
   @spec enclosing(t(), precision()) :: t()
-  def enclosing(%CalendarInterval{precision: old_precision} = interval, new_precision)
-      when new_precision in @precisions do
-    if precision_index(new_precision) < precision_index(old_precision) do
-      interval.first |> truncate(new_precision) |> new(new_precision)
-    else
-      raise ArgumentError,
-            "cannot enclose from #{inspect(old_precision)} to #{inspect(new_precision)}"
+  def enclosing(%CalendarInterval{precision: old_precision} = interval, new_precision) do
+    validate_precision(new_precision)
+
+    case Precision.compare(old_precision, new_precision) do
+      :eq ->
+        interval
+
+      :gt ->
+        interval.first |> Precision.truncate(new_precision) |> new(new_precision)
+
+      _ ->
+        raise ArgumentError,
+              "cannot enclose from #{inspect(old_precision)} to #{inspect(new_precision)}"
     end
-  end
-
-  defp truncate(ndt, :year), do: truncate(%{ndt | month: 1}, :month)
-  defp truncate(ndt, :month), do: truncate(%{ndt | day: 1}, :day)
-  defp truncate(ndt, :day), do: %{ndt | hour: 0, minute: 0, second: 0, microsecond: {0, 6}}
-  defp truncate(ndt, :hour), do: %{ndt | minute: 0, second: 0, microsecond: {0, 6}}
-  defp truncate(ndt, :minute), do: %{ndt | second: 0, microsecond: {0, 6}}
-  defp truncate(ndt, :second), do: %{ndt | microsecond: {0, 6}}
-  defp truncate(ndt, @microsecond), do: ndt
-
-  defp truncate(%{microsecond: {microsecond, _}} = ndt, {:microsecond, precision}) do
-    {1, n} = precision_to_count_unit({:microsecond, 6 - precision})
-    %{ndt | microsecond: {div(microsecond, n) * n, 6}}
-  end
-
-  for {precision, index} <- Enum.with_index(@precisions) do
-    defp precision_index(unquote(precision)), do: unquote(index)
   end
 
   @doc """
@@ -604,7 +505,7 @@ defmodule CalendarInterval do
   def union(interval1, interval2)
 
   def union(%CalendarInterval{precision: p} = i1, %CalendarInterval{precision: p} = i2) do
-    if intersection(i1, i2) != nil or next_ndt(i1.last, @microsecond, 1) == i2.first do
+    if intersection(i1, i2) != nil or Precision.next_ndt(i1.last, @microsecond, 1) == i2.first do
       new(i1.first, i2.last, p)
     else
       nil
@@ -644,10 +545,10 @@ defmodule CalendarInterval do
       interval1 == interval2 ->
         :equal
 
-      interval2.first == next_ndt(interval1.last, @microsecond, 1) ->
+      interval2.first == Precision.next_ndt(interval1.last, @microsecond, 1) ->
         :meets
 
-      interval2.last == prev_ndt(interval1.first, @microsecond, 1) ->
+      interval2.last == Precision.prev_ndt(interval1.first, @microsecond, 1) ->
         :met_by
 
       lt?(interval1.last, interval2.first) ->

--- a/lib/calendar_interval/common_date_manipulation.ex
+++ b/lib/calendar_interval/common_date_manipulation.ex
@@ -9,21 +9,21 @@ defmodule CalendarInterval.CommonDateManipulation do
   end
 
   @doc false
-  def common_count(%{year: year1}, %{year: year2}, :year),
+  def count(%{year: year1}, %{year: year2}, :year),
     do: year2 - year1 + 1
 
-  def common_count(%{year: year1, month: month1}, %{year: year2, month: month2}, :month),
+  def count(%{year: year1, month: month1}, %{year: year2, month: month2}, :month),
     do: month2 + year2 * 12 - month1 - year1 * 12 + 1
 
-  def common_count(first, last, precision) do
+  def count(first, last, precision) do
     {count, unit} = precision_to_count_unit(precision)
     div(NaiveDateTime.diff(last, first, unit), count) + 1
   end
 
   @doc false
-  def common_next_ndt(ndt, :year, step), do: update_in(ndt.year, &(&1 + step))
+  def next_ndt(ndt, :year, step), do: update_in(ndt.year, &(&1 + step))
 
-  def common_next_ndt(%NaiveDateTime{year: year, month: month} = ndt, :month, step) do
+  def next_ndt(%NaiveDateTime{year: year, month: month} = ndt, :month, step) do
     {plus_year, month} = {div(month + step, 12), rem(month + step, 12)}
 
     if month == 0 do
@@ -33,39 +33,39 @@ defmodule CalendarInterval.CommonDateManipulation do
     end
   end
 
-  def common_next_ndt(ndt, precision, step) do
+  def next_ndt(ndt, precision, step) do
     {count, unit} = precision_to_count_unit(precision)
     NaiveDateTime.add(ndt, count * step, unit)
   end
 
   @doc false
-  def common_prev_ndt(ndt, :year, step), do: update_in(ndt.year, &(&1 - step))
+  def prev_ndt(ndt, :year, step), do: update_in(ndt.year, &(&1 - step))
 
   # TODO: handle step != 1
-  def common_prev_ndt(%NaiveDateTime{year: year, month: 1} = ndt, :month, step) do
+  def prev_ndt(%NaiveDateTime{year: year, month: 1} = ndt, :month, step) do
     %{ndt | year: year - 1, month: 12 - step + 1}
   end
 
   # TODO: handle step != 1
-  def common_prev_ndt(%NaiveDateTime{month: month} = ndt, :month, step) do
+  def prev_ndt(%NaiveDateTime{month: month} = ndt, :month, step) do
     %{ndt | month: month - step}
   end
 
-  def common_prev_ndt(ndt, precision, step) do
+  def prev_ndt(ndt, precision, step) do
     {count, unit} = precision_to_count_unit(precision)
     NaiveDateTime.add(ndt, -count * step, unit)
   end
 
   @doc false
-  def common_truncate(ndt, :year), do: common_truncate(%{ndt | month: 1}, :month)
-  def common_truncate(ndt, :month), do: common_truncate(%{ndt | day: 1}, :day)
-  def common_truncate(ndt, :day), do: %{ndt | hour: 0, minute: 0, second: 0, microsecond: {0, 6}}
-  def common_truncate(ndt, :hour), do: %{ndt | minute: 0, second: 0, microsecond: {0, 6}}
-  def common_truncate(ndt, :minute), do: %{ndt | second: 0, microsecond: {0, 6}}
-  def common_truncate(ndt, :second), do: %{ndt | microsecond: {0, 6}}
-  def common_truncate(ndt, {:microsecond, 6}), do: ndt
+  def truncate(ndt, :year), do: truncate(%{ndt | month: 1}, :month)
+  def truncate(ndt, :month), do: truncate(%{ndt | day: 1}, :day)
+  def truncate(ndt, :day), do: %{ndt | hour: 0, minute: 0, second: 0, microsecond: {0, 6}}
+  def truncate(ndt, :hour), do: %{ndt | minute: 0, second: 0, microsecond: {0, 6}}
+  def truncate(ndt, :minute), do: %{ndt | second: 0, microsecond: {0, 6}}
+  def truncate(ndt, :second), do: %{ndt | microsecond: {0, 6}}
+  def truncate(ndt, {:microsecond, 6}), do: ndt
 
-  def common_truncate(%{microsecond: {microsecond, _}} = ndt, {:microsecond, precision}) do
+  def truncate(%{microsecond: {microsecond, _}} = ndt, {:microsecond, precision}) do
     {1, n} = precision_to_count_unit({:microsecond, 6 - precision})
     %{ndt | microsecond: {div(microsecond, n) * n, 6}}
   end

--- a/lib/calendar_interval/common_date_manipulation.ex
+++ b/lib/calendar_interval/common_date_manipulation.ex
@@ -1,0 +1,72 @@
+defmodule CalendarInterval.CommonDateManipulation do
+  defp precision_to_count_unit(:day), do: {24 * 60 * 60, :second}
+  defp precision_to_count_unit(:hour), do: {60 * 60, :second}
+  defp precision_to_count_unit(:minute), do: {60, :second}
+  defp precision_to_count_unit(:second), do: {1, :second}
+
+  defp precision_to_count_unit({:microsecond, exponent}) do
+    {1, Enum.reduce(1..exponent, 1, fn _, acc -> acc * 10 end)}
+  end
+
+  @doc false
+  def common_count(%{year: year1}, %{year: year2}, :year),
+    do: year2 - year1 + 1
+
+  def common_count(%{year: year1, month: month1}, %{year: year2, month: month2}, :month),
+    do: month2 + year2 * 12 - month1 - year1 * 12 + 1
+
+  def common_count(first, last, precision) do
+    {count, unit} = precision_to_count_unit(precision)
+    div(NaiveDateTime.diff(last, first, unit), count) + 1
+  end
+
+  @doc false
+  def common_next_ndt(ndt, :year, step), do: update_in(ndt.year, &(&1 + step))
+
+  def common_next_ndt(%NaiveDateTime{year: year, month: month} = ndt, :month, step) do
+    {plus_year, month} = {div(month + step, 12), rem(month + step, 12)}
+
+    if month == 0 do
+      %{ndt | year: year + plus_year, month: 1}
+    else
+      %{ndt | year: year + plus_year, month: month}
+    end
+  end
+
+  def common_next_ndt(ndt, precision, step) do
+    {count, unit} = precision_to_count_unit(precision)
+    NaiveDateTime.add(ndt, count * step, unit)
+  end
+
+  @doc false
+  def common_prev_ndt(ndt, :year, step), do: update_in(ndt.year, &(&1 - step))
+
+  # TODO: handle step != 1
+  def common_prev_ndt(%NaiveDateTime{year: year, month: 1} = ndt, :month, step) do
+    %{ndt | year: year - 1, month: 12 - step + 1}
+  end
+
+  # TODO: handle step != 1
+  def common_prev_ndt(%NaiveDateTime{month: month} = ndt, :month, step) do
+    %{ndt | month: month - step}
+  end
+
+  def common_prev_ndt(ndt, precision, step) do
+    {count, unit} = precision_to_count_unit(precision)
+    NaiveDateTime.add(ndt, -count * step, unit)
+  end
+
+  @doc false
+  def common_truncate(ndt, :year), do: common_truncate(%{ndt | month: 1}, :month)
+  def common_truncate(ndt, :month), do: common_truncate(%{ndt | day: 1}, :day)
+  def common_truncate(ndt, :day), do: %{ndt | hour: 0, minute: 0, second: 0, microsecond: {0, 6}}
+  def common_truncate(ndt, :hour), do: %{ndt | minute: 0, second: 0, microsecond: {0, 6}}
+  def common_truncate(ndt, :minute), do: %{ndt | second: 0, microsecond: {0, 6}}
+  def common_truncate(ndt, :second), do: %{ndt | microsecond: {0, 6}}
+  def common_truncate(ndt, {:microsecond, 6}), do: ndt
+
+  def common_truncate(%{microsecond: {microsecond, _}} = ndt, {:microsecond, precision}) do
+    {1, n} = precision_to_count_unit({:microsecond, 6 - precision})
+    %{ndt | microsecond: {div(microsecond, n) * n, 6}}
+  end
+end

--- a/lib/calendar_interval/precision.ex
+++ b/lib/calendar_interval/precision.ex
@@ -11,8 +11,8 @@ defmodule CalendarInterval.Precision do
   @callback precisions() :: [precision, ...]
   @callback count(first :: NaiveDateTime.t(), last :: NaiveDateTime.t(), precision) ::
               non_neg_integer()
-  @callback prev_ndt(NaiveDateTime.t(), precision, non_neg_integer()) :: NaiveDateTime.t()
-  @callback next_ndt(NaiveDateTime.t(), precision, non_neg_integer()) :: NaiveDateTime.t()
+  @callback prev_ndt(NaiveDateTime.t(), precision, pos_integer()) :: NaiveDateTime.t()
+  @callback next_ndt(NaiveDateTime.t(), precision, pos_integer()) :: NaiveDateTime.t()
   @callback truncate(NaiveDateTime.t(), precision) :: NaiveDateTime.t()
 
   @doc "List all available precisions."
@@ -86,6 +86,8 @@ defmodule CalendarInterval.Precision do
 
   @doc "Go a number of steps back in time by the given precision."
   @spec prev_ndt(NaiveDateTime.t(), precision, non_neg_integer()) :: NaiveDateTime.t()
+  def prev_ndt(ndt, _precision, 0), do: ndt
+
   def prev_ndt(ndt, precision, step) do
     module = module_for_precision(precision)
     module.prev_ndt(ndt, precision, step)
@@ -93,6 +95,8 @@ defmodule CalendarInterval.Precision do
 
   @doc "Go a number of steps forward in time by the given precision."
   @spec next_ndt(NaiveDateTime.t(), precision, non_neg_integer()) :: NaiveDateTime.t()
+  def next_ndt(ndt, _precision, 0), do: ndt
+
   def next_ndt(ndt, precision, step) do
     module = module_for_precision(precision)
     module.next_ndt(ndt, precision, step)
@@ -180,21 +184,10 @@ for {precision, bytes, rest} <- patterns do
 
     def format_left_right(_, _), do: :nomatch
 
-    defdelegate count(first, last, precision),
-      to: CalendarInterval.CommonDateManipulation,
-      as: :common_count
-
-    defdelegate truncate(ndt, precision),
-      to: CalendarInterval.CommonDateManipulation,
-      as: :common_truncate
-
-    defdelegate prev_ndt(ndt, precision, step),
-      to: CalendarInterval.CommonDateManipulation,
-      as: :common_prev_ndt
-
-    defdelegate next_ndt(ndt, precision, step),
-      to: CalendarInterval.CommonDateManipulation,
-      as: :common_next_ndt
+    defdelegate count(first, last, precision), to: CalendarInterval.CommonDateManipulation
+    defdelegate prev_ndt(ndt, precision, step), to: CalendarInterval.CommonDateManipulation
+    defdelegate next_ndt(ndt, precision, step), to: CalendarInterval.CommonDateManipulation
+    defdelegate truncate(ndt, precision), to: CalendarInterval.CommonDateManipulation
   end
 end
 
@@ -237,19 +230,8 @@ defmodule CalendarInterval.Precision.module_name(:microsecond) do
 
   def precisions, do: unquote(Enum.map(@scales, &elem(&1, 0)))
 
-  defdelegate count(first, last, precision),
-    to: CalendarInterval.CommonDateManipulation,
-    as: :common_count
-
-  defdelegate prev_ndt(ndt, precision, step),
-    to: CalendarInterval.CommonDateManipulation,
-    as: :common_prev_ndt
-
-  defdelegate next_ndt(ndt, precision, step),
-    to: CalendarInterval.CommonDateManipulation,
-    as: :common_next_ndt
-
-  defdelegate truncate(ndt, precision),
-    to: CalendarInterval.CommonDateManipulation,
-    as: :common_truncate
+  defdelegate count(first, last, precision), to: CalendarInterval.CommonDateManipulation
+  defdelegate prev_ndt(ndt, precision, step), to: CalendarInterval.CommonDateManipulation
+  defdelegate next_ndt(ndt, precision, step), to: CalendarInterval.CommonDateManipulation
+  defdelegate truncate(ndt, precision), to: CalendarInterval.CommonDateManipulation
 end

--- a/lib/calendar_interval/precision.ex
+++ b/lib/calendar_interval/precision.ex
@@ -1,0 +1,255 @@
+defmodule CalendarInterval.Precision do
+  @moduledoc """
+  Handle all the functionality CalendarIntervals use, which depends on the used precision.
+  """
+  @type precision() :: atom | {atom, scale :: term}
+
+  @callback to_iso8601(String.t()) :: {:ok, precision, String.t()} | :nomatch
+  @callback format(NaiveDateTime.t(), precision) :: String.t()
+  @callback format_left_right(left :: String.t(), right :: String.t()) ::
+              {:ok, String.t()} | :nomatch
+  @callback precisions() :: [precision, ...]
+  @callback count(first :: NaiveDateTime.t(), last :: NaiveDateTime.t(), precision) ::
+              non_neg_integer()
+  @callback prev_ndt(NaiveDateTime.t(), precision, non_neg_integer()) :: NaiveDateTime.t()
+  @callback next_ndt(NaiveDateTime.t(), precision, non_neg_integer()) :: NaiveDateTime.t()
+  @callback truncate(NaiveDateTime.t(), precision) :: NaiveDateTime.t()
+
+  @doc "List all available precisions."
+  @spec precisions() :: [precision]
+  def precisions do
+    Enum.map(available_precisions_mapping(), &elem(&1, 0))
+  end
+
+  @doc "Assert if a precision is currently registered."
+  @spec valid?(precision) :: boolean
+  def valid?(precision) do
+    precision in precisions()
+  end
+
+  @doc "Compare precisions by their granularity"
+  @spec compare(precision, precision) :: :lt | :eq | :gt
+  def compare(left, right) when left == right, do: :eq
+
+  def compare(left, right) do
+    Enum.find_value(precisions(), fn
+      ^left -> :lt
+      ^right -> :gt
+      _ -> false
+    end)
+  end
+
+  @doc "Parse a string and try to determine the intended precision."
+  @spec parse(String.t()) :: {:ok, precision, String.t()} | :error
+  def parse(string) do
+    result =
+      Enum.find_value(available_precision_modules(), fn module ->
+        case module.to_iso8601(string) do
+          {:ok, precision, str} -> {:ok, precision, str}
+          :nomatch -> false
+        end
+      end)
+
+    result || :error
+  end
+
+  @doc "Format the given date using a specific precision."
+  @spec format(NaiveDateTime.t(), precision) :: String.t()
+  def format(ndt, precision) do
+    module = module_for_precision(precision)
+    module.format(ndt, precision)
+  end
+
+  @doc "Pack together left and right formatted values in a shorter version."
+  @spec format_left_right(String.t(), String.t(), precision) :: String.t()
+  def format_left_right(left, left, _) do
+    left
+  end
+
+  def format_left_right(left, right) do
+    available_precision_modules()
+    |> Enum.reverse()
+    |> Enum.find_value("#{left}/#{right}", fn module ->
+      case module.format_left_right(left, right) do
+        {:ok, str} -> str
+        :nomatch -> false
+      end
+    end)
+  end
+
+  @doc "Count the number of elements in the range between first and last"
+  @spec count(NaiveDateTime.t(), NaiveDateTime.t(), precision) :: non_neg_integer()
+  def count(first, last, precision) do
+    module = module_for_precision(precision)
+    module.count(first, last, precision)
+  end
+
+  @doc "Go a number of steps back in time by the given precision."
+  @spec prev_ndt(NaiveDateTime.t(), precision, non_neg_integer()) :: NaiveDateTime.t()
+  def prev_ndt(ndt, precision, step) do
+    module = module_for_precision(precision)
+    module.prev_ndt(ndt, precision, step)
+  end
+
+  @doc "Go a number of steps forward in time by the given precision."
+  @spec next_ndt(NaiveDateTime.t(), precision, non_neg_integer()) :: NaiveDateTime.t()
+  def next_ndt(ndt, precision, step) do
+    module = module_for_precision(precision)
+    module.next_ndt(ndt, precision, step)
+  end
+
+  @doc "Truncate the place in time by the given precision."
+  @spec truncate(NaiveDateTime.t(), precision) :: NaiveDateTime.t()
+  def truncate(ndt, precision) do
+    module = module_for_precision(precision)
+    module.truncate(ndt, precision)
+  end
+
+  # Helpers
+
+  defp module_for_precision(precision) do
+    case List.keyfind(available_precisions_mapping(), precision, 0) do
+      nil -> raise("Tried to use precision #{precision}, which is no longer registered.")
+      {_, module} -> module
+    end
+  end
+
+  defp available_precisions_mapping do
+    # These are defined below this module
+    [:year, :month, :day, :hour, :minute, :second, :microsecond]
+    |> Enum.flat_map(fn key ->
+      module = module_name(key)
+      Enum.map(module.precisions(), &{&1, module})
+    end)
+    |> maybe_add_precisions()
+  end
+
+  defp maybe_add_precisions(list) do
+    maybe_add_precisions(list, Application.get_env(:calendar_interval, :precisions_modifier))
+  end
+
+  defp maybe_add_precisions(list, {m, f}) do
+    apply(m, f, [list])
+  end
+
+  defp maybe_add_precisions(list, _), do: list
+
+  defp available_precision_modules do
+    available_precisions_mapping()
+    |> Enum.map(&elem(&1, 1))
+    |> Enum.uniq()
+  end
+
+  @doc false
+  def module_name(precision_key) do
+    module = String.capitalize(Atom.to_string(precision_key))
+    Module.concat([__MODULE__, module])
+  end
+end
+
+patterns = [
+  {:year, 4, "-01-01 00:00:00.000000"},
+  {:month, 7, "-01 00:00:00.000000"},
+  {:day, 10, " 00:00:00.000000"},
+  {:hour, 13, ":00:00.000000"},
+  {:minute, 16, ":00.000000"},
+  {:second, 19, ".000000"}
+]
+
+for {precision, bytes, rest} <- patterns do
+  defmodule CalendarInterval.Precision.module_name(precision) do
+    @behaviour CalendarInterval.Precision
+    def to_iso8601(string) when byte_size(string) == unquote(bytes) do
+      {:ok, unquote(precision), string <> unquote(rest)}
+    end
+
+    def to_iso8601(_), do: :nomatch
+
+    def precisions, do: [unquote(precision)]
+
+    def format(ndt, unquote(precision)) do
+      String.slice(NaiveDateTime.to_string(ndt), 0, unquote(bytes))
+    end
+
+    def format_left_right(
+          <<left::unquote(bytes + 1)-bytes>> <> left_rest,
+          <<left::unquote(bytes + 1)-bytes>> <> right_rest
+        ) do
+      {:ok, left <> left_rest <> "/" <> right_rest}
+    end
+
+    def format_left_right(_, _), do: :nomatch
+
+    defdelegate count(first, last, precision),
+      to: CalendarInterval.CommonDateManipulation,
+      as: :common_count
+
+    defdelegate truncate(ndt, precision),
+      to: CalendarInterval.CommonDateManipulation,
+      as: :common_truncate
+
+    defdelegate prev_ndt(ndt, precision, step),
+      to: CalendarInterval.CommonDateManipulation,
+      as: :common_prev_ndt
+
+    defdelegate next_ndt(ndt, precision, step),
+      to: CalendarInterval.CommonDateManipulation,
+      as: :common_next_ndt
+  end
+end
+
+defmodule CalendarInterval.Precision.module_name(:microsecond) do
+  @behaviour CalendarInterval.Precision
+
+  @scales [
+    {{:microsecond, 1}, 21, "00000"},
+    {{:microsecond, 2}, 22, "0000"},
+    {{:microsecond, 3}, 23, "000"},
+    {{:microsecond, 4}, 24, "00"},
+    {{:microsecond, 5}, 25, "0"},
+    {{:microsecond, 6}, 26, ""}
+  ]
+
+  for {precision, bytes, rest} <- @scales do
+    def to_iso8601(string) when byte_size(string) == unquote(bytes) do
+      {:ok, unquote(precision), string <> unquote(rest)}
+    end
+  end
+
+  def to_iso8601(_), do: :nomatch
+
+  for {precision, bytes, _rest} <- @scales do
+    def format(ndt, unquote(precision)) do
+      String.slice(NaiveDateTime.to_string(ndt), 0, unquote(bytes))
+    end
+  end
+
+  for {_precision, bytes, _rest} <- Enum.reverse(@scales) do
+    def format_left_right(
+          <<left::unquote(bytes + 1)-bytes>> <> left_rest,
+          <<left::unquote(bytes + 1)-bytes>> <> right_rest
+        ) do
+      left <> left_rest <> "/" <> right_rest
+    end
+  end
+
+  def format_left_right(_, _), do: :nomatch
+
+  def precisions, do: unquote(Enum.map(@scales, &elem(&1, 0)))
+
+  defdelegate count(first, last, precision),
+    to: CalendarInterval.CommonDateManipulation,
+    as: :common_count
+
+  defdelegate prev_ndt(ndt, precision, step),
+    to: CalendarInterval.CommonDateManipulation,
+    as: :common_prev_ndt
+
+  defdelegate next_ndt(ndt, precision, step),
+    to: CalendarInterval.CommonDateManipulation,
+    as: :common_next_ndt
+
+  defdelegate truncate(ndt, precision),
+    to: CalendarInterval.CommonDateManipulation,
+    as: :common_truncate
+end

--- a/test/calendar_interval_test.exs
+++ b/test/calendar_interval_test.exs
@@ -30,7 +30,7 @@ defmodule CalendarIntervalTest do
     assert i.first == ~N"2018-06-15 00:00:00.000000"
     assert i.last == ~N"2018-06-16 23:59:59.999999"
 
-    assert_raise ArgumentError, ~r"cannot create interval from 2018-06-15 and 2018-06-14", fn ->
+    assert_raise ArgumentError, ~r"Cannot create interval from 2018-06-15 and 2018-06-14", fn ->
       I.parse!("2018-06-15/14")
     end
   end

--- a/test/precision_test.exs
+++ b/test/precision_test.exs
@@ -2,42 +2,7 @@ defmodule CalendarInterval.PrecisionTest do
   use ExUnit.Case
   alias CalendarInterval.Precision
 
-  defmodule Quarter do
-    @behaviour CalendarInterval.Precision
-
-    @quarter_to_month %{
-      "1" => "01",
-      "2" => "04",
-      "3" => "07",
-      "4" => "10"
-    }
-
-    def to_iso8601(<<year::4-bytes, "Q", quarter::1-bytes>>)
-        when quarter in ["1", "2", "3", "4"] do
-      {:ok, :quarter, "#{year}-#{@quarter_to_month[quarter]}-01 00:00:00.000000"}
-    end
-
-    def to_iso8601(_), do: :nomatch
-
-    def format(ndt, :quarter) do
-      q =
-        case ndt.month do
-          1 -> 1
-          4 -> 2
-          7 -> 3
-          10 -> 4
-        end
-
-      "#{ndt.year}Q#{q}"
-    end
-
-    def register(list) do
-      Enum.flat_map(list, fn
-        {:year, _} = el -> [el, {:quarter, __MODULE__}]
-        el -> [el]
-      end)
-    end
-  end
+  Code.require_file("quarter.exs", "test/support")
 
   describe "default state" do
     test "precisions" do

--- a/test/precision_test.exs
+++ b/test/precision_test.exs
@@ -1,0 +1,170 @@
+defmodule CalendarInterval.PrecisionTest do
+  use ExUnit.Case
+  alias CalendarInterval.Precision
+
+  defmodule Quarter do
+    @behaviour CalendarInterval.Precision
+
+    @quarter_to_month %{
+      "1" => "01",
+      "2" => "04",
+      "3" => "07",
+      "4" => "10"
+    }
+
+    def to_iso8601(<<year::4-bytes, "Q", quarter::1-bytes>>)
+        when quarter in ["1", "2", "3", "4"] do
+      {:ok, :quarter, "#{year}-#{@quarter_to_month[quarter]}-01 00:00:00.000000"}
+    end
+
+    def to_iso8601(_), do: :nomatch
+
+    def format(ndt, :quarter) do
+      q =
+        case ndt.month do
+          1 -> 1
+          4 -> 2
+          7 -> 3
+          10 -> 4
+        end
+
+      "#{ndt.year}Q#{q}"
+    end
+
+    def register(list) do
+      Enum.flat_map(list, fn
+        {:year, _} = el -> [el, {:quarter, __MODULE__}]
+        el -> [el]
+      end)
+    end
+  end
+
+  describe "default state" do
+    test "precisions" do
+      expected = [
+        :year,
+        :month,
+        :day,
+        :hour,
+        :minute,
+        :second,
+        {:microsecond, 1},
+        {:microsecond, 2},
+        {:microsecond, 3},
+        {:microsecond, 4},
+        {:microsecond, 5},
+        {:microsecond, 6}
+      ]
+
+      assert expected == Precision.precisions()
+    end
+
+    test "default precisions are valid" do
+      for precision <- Precision.precisions() do
+        assert Precision.valid?(precision)
+      end
+    end
+
+    test "compare" do
+      indexed_precisions = Enum.with_index(Precision.precisions())
+
+      for {precision, index} <- indexed_precisions do
+        {before, [{current, _} | beyond]} =
+          Enum.split_while(indexed_precisions, fn {_, i} -> i < index end)
+
+        for {b, _} <- before do
+          assert Precision.compare(precision, b) == :gt
+        end
+
+        assert Precision.compare(precision, current) == :eq
+
+        for {b, _} <- beyond do
+          assert Precision.compare(precision, b) == :lt
+        end
+      end
+    end
+  end
+
+  describe "with additional precision" do
+    setup do
+      Application.put_env(:calendar_interval, :precisions_modifier, {Quarter, :register})
+
+      on_exit(fn ->
+        Application.delete_env(:calendar_interval, :precisions_modifier)
+      end)
+    end
+
+    test "precisions" do
+      expected = [
+        :year,
+        :quarter,
+        :month,
+        :day,
+        :hour,
+        :minute,
+        :second,
+        {:microsecond, 1},
+        {:microsecond, 2},
+        {:microsecond, 3},
+        {:microsecond, 4},
+        {:microsecond, 5},
+        {:microsecond, 6}
+      ]
+
+      assert expected == Precision.precisions()
+    end
+
+    test "added precisions are valid" do
+      assert Precision.valid?(:quarter)
+    end
+
+    test "compare" do
+      precision = :quarter
+
+      before = [:year]
+      current = :quarter
+
+      beyond = [
+        :month,
+        :day,
+        :hour,
+        :minute,
+        :second,
+        {:microsecond, 1},
+        {:microsecond, 2},
+        {:microsecond, 3},
+        {:microsecond, 4},
+        {:microsecond, 5},
+        {:microsecond, 6}
+      ]
+
+      for {b, _} <- before do
+        assert Precision.compare(precision, b) == :gt
+      end
+
+      assert Precision.compare(precision, current) == :eq
+
+      for {b, _} <- beyond do
+        assert Precision.compare(precision, b) == :lt
+      end
+    end
+
+    test "parse quarter" do
+      assert {:ok, :quarter, "2019-04-01 00:00:00.000000"} = Precision.parse("2019Q2")
+    end
+
+    test "other precisions can still be parsed" do
+      assert {:ok, :year, "2019-01-01 00:00:00.000000"} = Precision.parse("2019")
+      assert {:ok, :month, "2019-02-01 00:00:00.000000"} = Precision.parse("2019-02")
+    end
+
+    test "format quarter" do
+      assert "2019Q2" = Precision.format(~N[2019-04-01 00:00:00], :quarter)
+    end
+
+    test "other precisions can still be formated" do
+      assert "2019" = Precision.format(~N[2019-01-01 00:00:00], :year)
+      assert "2019-02" = Precision.format(~N[2019-02-01 00:00:00], :month)
+    end
+  end
+end

--- a/test/support/quarter.exs
+++ b/test/support/quarter.exs
@@ -1,0 +1,73 @@
+defmodule Quarter do
+  @behaviour CalendarInterval.Precision
+
+  @quarter_to_month %{
+    "1" => "01",
+    "2" => "04",
+    "3" => "07",
+    "4" => "10"
+  }
+
+  def to_iso8601(<<year::4-bytes, "Q", quarter::1-bytes>>)
+      when quarter in ["1", "2", "3", "4"] do
+    {:ok, :quarter, "#{year}-#{@quarter_to_month[quarter]}-01 00:00:00.000000"}
+  end
+
+  def to_iso8601(_), do: :nomatch
+
+  def precisions, do: [:quarter]
+
+  def count(first, last, :quarter) do
+    div(CalendarInterval.CommonDateManipulation.count(first, last, :month), 3)
+  end
+
+  def format(ndt, :quarter) do
+    ndt = truncate(ndt, :quarter)
+
+    q =
+      case ndt.month do
+        1 -> 1
+        4 -> 2
+        7 -> 3
+        10 -> 4
+      end
+
+    "#{ndt.year}Q#{q}"
+  end
+
+  def format_left_right(
+        <<year_left::4-bytes, "Q", quarter_left::1-bytes>>,
+        <<year_left::4-bytes, "Q", quarter_right::1-bytes>>
+      )
+      when quarter_left in ["1", "2", "3", "4"] and quarter_right in ["1", "2", "3", "4"] do
+    {:ok, "#{year_left}Q#{quarter_left}/Q#{quarter_right}"}
+  end
+
+  def format_left_right(_, _), do: :nomatch
+
+  def next_ndt(ndt, :quarter, _step) do
+    ndt
+    |> CalendarInterval.CommonDateManipulation.next_ndt(:month, 1)
+    |> CalendarInterval.CommonDateManipulation.next_ndt(:month, 1)
+    |> CalendarInterval.CommonDateManipulation.next_ndt(:month, 1)
+  end
+
+  def prev_ndt(ndt, :quarter, _step) do
+    ndt
+    |> CalendarInterval.CommonDateManipulation.prev_ndt(:month, 1)
+    |> CalendarInterval.CommonDateManipulation.prev_ndt(:month, 1)
+    |> CalendarInterval.CommonDateManipulation.prev_ndt(:month, 1)
+  end
+
+  def truncate(ndt, :quarter) do
+    month = div(ndt.month - 1, 3) * 3 + 1
+    CalendarInterval.CommonDateManipulation.truncate(%{ndt | month: month}, :month)
+  end
+
+  def register(list) do
+    Enum.flat_map(list, fn
+      {:year, _} = el -> [el, {:quarter, __MODULE__}]
+      el -> [el]
+    end)
+  end
+end


### PR DESCRIPTION
There has quite a bit happened here, so I'll give a bit of context:

- I extracted all functionality, which involves knowledge about a certain precision into `CalendarInterval. Precision`.
- `CalendarInterval. Precision` takes the list of known precision implementations and uses those to fulfill the requested tasks. Putting functionality in their own modules seemed like a good way to keep things like the pattern matching. 
- I extracted the datetime manipulation functionalities, because I was to lazy to devide it up between the generated native precisions and it also seems to work ok for building the custom precision for the test on top of.

This is not yet ready, but I'd appreciate feedback on it.